### PR TITLE
dnsmasq: use strict-order when DNSCrypt is enabled.

### DIFF
--- a/release/src/router/rc/services.c
+++ b/release/src/router/rc/services.c
@@ -387,13 +387,13 @@ void start_dnsmasq()
 	}
 #endif
 
-/*
+
 #ifdef TCONFIG_DNSCRYPT
 	if (nvram_match("dnscrypt_proxy", "1")) {
 		fprintf(f, "strict-order\n");
 	}
 #endif
-*/
+
 	//
 
 #ifdef TCONFIG_OPENVPN


### PR DESCRIPTION
Without strict-order, it is likely dnscrypt will not be used at all since ISP nameservers will likely respond faster than OpenDNS.  Users should understand that enabling dnscrypt may sacrifice speed in exchange for security. There are now many dnscrypt enabled servers available, so this may alleviate speed issues for some users if they specify a different server closer to them, by using the custom config.  

Last I remember though, the custom config area may be broken, and may need to be addressed.
http://linksysinfo.org/index.php?threads/shibby-issues-with-dnscrypt-proxy.68433/#post-244308
http://linksysinfo.org/index.php?threads/bug-shibby-tomato-dnscrypt-custom-startup-paremeters.69659/

edit:sorry, didn't mean to close/reopen the issue.
