### PR TITLE
dnscrypt: Add dns priority option.

### DIFF
--- a/release/src/router/httpd/tomato.c
+++ b/release/src/router/httpd/tomato.c
@@ -577,6 +577,7 @@ static const nvset_t nvset_list[] = {
 
 #ifdef TCONFIG_DNSCRYPT
 	{ "dnscrypt_proxy",		V_01				},
+	{ "dnscrypt_priority",		V_RANGE(0, 2)			}, // 0=none, 1=preferred, 2=exclusive
 	{ "dnscrypt_port",		V_PORT				},
 	{ "dnscrypt_cmd",		V_LENGTH(0, 256)	},
 #endif
@@ -745,7 +746,6 @@ static const nvset_t nvset_list[] = {
 	{ "dnsmasq_custom",		V_TEXT(0, 2048)		},
 	{ "dnsmasq_q",			V_RANGE(0, 7)		}, // 0= quiet-dhcp, 1=dhcp6 2=ra
 	{ "dhcpd_static_only",		V_01			},
-	{ "dnsmasq_strict_order",	V_01			}, // read etc/resolv.conf in the given order. If null --no-resolv
 	
 // advanced-firewall
 	{ "block_wan",			V_01			},

--- a/release/src/router/nvram/defaults.c
+++ b/release/src/router/nvram/defaults.c
@@ -94,6 +94,7 @@ const defaults_t defaults[] = {
 #endif
 #ifdef TCONFIG_DNSCRYPT
 	{ "dnscrypt_proxy",		""				},
+	{ "dnscrypt_priority",		"1"			}, // 0=none, 1=preferred, 2=exclusive
 	{ "dnscrypt_port",		"40"			}, // local port
 	{ "dnscrypt_cmd",		"-m 99"			}, // optional arguments
 #endif
@@ -442,7 +443,6 @@ const defaults_t defaults[] = {
 	{ "dnsmasq_custom",		""				},
 	{ "dnsmasq_static_only",	"0"			},
 	{ "dnsmasq_q",			"0"				},      // 0= quiet-dhcp 1=dhcp6 2=ra
-	{ "dnsmasq_strict_order",	"1"				}, // read etc/resolv.conf in the given order. If null --no-resolv
 	
 // advanced-firewall
 //	{ "block_loopback",		"0"				},	// nat loopback

--- a/release/src/router/rc/services.c
+++ b/release/src/router/rc/services.c
@@ -389,10 +389,13 @@ void start_dnsmasq()
 
 #ifdef TCONFIG_DNSCRYPT
 	if (nvram_match("dnscrypt_proxy", "1")) {
-		if (nvram_match("dnsmasq_strict_order", "1"))
+		if (nvram_match("dnscrypt_priority", "1")){
 			fprintf(f, "strict-order\n");
-		else
+		}
+
+		if (nvram_match("dnscrypt_priority", "2")){
 			fprintf(f, "no-resolv\n");
+		}
 	}
 #endif
 

--- a/release/src/router/www/advanced-dhcpdns.asp
+++ b/release/src/router/www/advanced-dhcpdns.asp
@@ -29,7 +29,7 @@ textarea {
 
 <script type='text/javascript'>
 
-//	<% nvram("dnsmasq_q,ipv6_radvd,dhcpd_dmdns,dns_addget,dhcpd_gwmode,dns_intcpt,dhcpd_slt,dhcpc_minpkt,dnsmasq_custom,dnsmasq_strict_order,dnsmasq_norw,dhcpd_lmax,dhcpc_custom,dns_norebind,dhcpd_static_only"); %>
+//	<% nvram("dnsmasq_q,ipv6_radvd,dhcpd_dmdns,dns_addget,dhcpd_gwmode,dns_intcpt,dhcpd_slt,dhcpc_minpkt,dnsmasq_custom,dnsmasq_norw,dhcpd_lmax,dhcpc_custom,dns_norebind,dhcpd_static_only"); %>
 
 if ((isNaN(nvram.dhcpd_lmax)) || ((nvram.dhcpd_lmax *= 1) < 1)) nvram.dhcpd_lmax = 255;
 
@@ -60,7 +60,6 @@ function save()
 	a = E('_f_dhcpd_sltsel').value;
 	fom.dhcpd_slt.value = (a != 1) ? a : E('_f_dhcpd_slt').value;
 	fom.dns_addget.value = E('_f_dns_addget').checked ? 1 : 0;
-	fom.dnsmasq_strict_order.value = E('_f_dns_strict_order').checked ? '1' : '0';
 	fom.dns_norebind.value = E('_f_dns_norebind').checked ? 1 : 0;
 	fom.dhcpd_gwmode.value = E('_f_dhcpd_gwmode').checked ? 1 : 0;
 	fom.dns_intcpt.value = E('_f_dns_intcpt').checked ? 1 : 0;
@@ -139,7 +138,6 @@ function init() {
 <input type='hidden' name='dhcpd_dmdns'>
 <input type='hidden' name='dhcpd_slt'>
 <input type='hidden' name='dns_addget'>
-<input type='hidden' name='dnsmasq_strict_order'>
 <input type='hidden' name='dns_norebind'>
 <input type='hidden' name='dhcpd_gwmode'>
 <input type='hidden' name='dns_intcpt'>
@@ -154,7 +152,6 @@ function init() {
 createFieldTable('', [
 	{ title: 'Use internal DNS', name: 'f_dhcpd_dmdns', type: 'checkbox', value: nvram.dhcpd_dmdns == '1' },
 	{ title: 'Use received DNS with user-entered DNS', name: 'f_dns_addget', type: 'checkbox', value: nvram.dns_addget == '1' },
-	{ title: 'Resolve in Strict Order OR Non Resolve', name: '_f_dns_strict_order', type: 'checkbox', value: nvram.dnsmasq_strict_order == '1' },
 	{ title: 'Prevent DNS-rebind attacks', name: 'f_dns_norebind', type: 'checkbox', value: nvram.dns_norebind == '1' },
 	{ title: 'Intercept DNS port<br>(UDP 53)', name: 'f_dns_intcpt', type: 'checkbox', value: nvram.dns_intcpt == '1' },
 	{ title: 'Use user-entered gateway if WAN is disabled', name: 'f_dhcpd_gwmode', type: 'checkbox', value: nvram.dhcpd_gwmode == '1' },
@@ -195,7 +192,6 @@ createFieldTable('', [
 <li><b>Important:</b> You must enter IPv4 and IPv6 DNS's to reject the ones provided by your ISP.</li>
 <li><b>Use internal DNS</b> - Allow dnsmasq to be your DNS server on LAN.</li>
 <li><b>Use received DNS with user-entered DNS</b> - Add DNS servers received from your WAN connection to the static DNS server list (see <a href='basic-network.asp'>Network</a> configuration).</li>
-<li><b>Resolve in Strict Order OR Non Resolve</b> - Dnsmasq will send queries to any of the upstream servers it knows about and tries to favour servers that are known to be up. Setting this checkbox; Forces dnsmasq to try each query with each server strictly in the order they appear in /etc/resolv.conf. Unchecking this checkbox; Don't read /etc/resolv.conf. Get upstream servers only from the command line or the dnsmasq configuration file.</li>
 <li><b>Prevent DNS-rebind attacks</b> - Enable DNS rebinding protection on Dnsmasq.</li>
 <li><b>Intercept DNS port</b> - Any DNS requests/packets sent out to UDP port 53 are redirected to the internal DNS server.</li>
 <li><b>Use user-entered gateway if WAN is disabled</b> - DHCP will use the IP address of the router as the default gateway on each LAN.</li>

--- a/release/src/router/www/basic-network.asp
+++ b/release/src/router/www/basic-network.asp
@@ -45,7 +45,7 @@
 <script type='text/javascript' src='wireless.jsx?_http_id=<% nv(http_id); %>'></script>
 <script type='text/javascript' src='interfaces.js'></script>
 <script type='text/javascript'>
-//	<% nvram("dhcp_lease,dhcp_num,dhcp_start,dhcpd_startip,dhcpd_endip,l2tp_server_ip,lan_gateway,lan_ipaddr,lan_netmask,lan_proto,lan_state,mtu_enable,ppp_demand,ppp_idletime,pppoe_lei,pppoe_lef,ppp_passwd,ppp_redialperiod,ppp_service,ppp_username,ppp_custom,pptp_server_ip,pptp_dhcp,wl_security_mode,wan_dns,dnssec_enable,dnscrypt_proxy,dnscrypt_port,dnscrypt_cmd,wan_gateway,wan_ipaddr,wan_mtu,wan_netmask,wan_proto,wan_wins,wl_wds_enable,wl_channel,wl_closed,wl_crypto,wl_key,wl_key1,wl_key2,wl_key3,wl_key4,wl_lazywds,wl_mode,wl_net_mode,wl_passphrase,wl_radio,wl_radius_ipaddr,wl_radius_port,wl_ssid,wl_wds,wl_wep_bit,wl_wpa_gtk_rekey,wl_wpa_psk,wl_radius_key,wl_auth,wl_hwaddr,wan_islan,t_features,wl_nbw_cap,wl_nctrlsb,wl_nband,wl_phytype,lan_ifname,lan_stp,lan1_ifname,lan1_ipaddr,lan1_netmask,lan1_proto,lan1_stp,dhcp1_start,dhcp1_num,dhcp1_lease,dhcpd1_startip,dhcpd1_endip,lan2_ifname,lan2_ipaddr,lan2_netmask,lan2_proto,lan2_stp,dhcp2_start,dhcp2_num,dhcp2_lease,dhcpd2_startip,dhcpd2_endip,lan3_ifname,lan3_ipaddr,lan3_netmask,lan3_proto,lan3_stp,dhcp3_start,dhcp3_num,dhcp3_lease,dhcpd3_startip,dhcpd3_endip,ppp_mlppp,modem_ipaddr,modem_pin,modem_dev,modem_init,modem_apn,cstats_enable"); %>
+//	<% nvram("dhcp_lease,dhcp_num,dhcp_start,dhcpd_startip,dhcpd_endip,l2tp_server_ip,lan_gateway,lan_ipaddr,lan_netmask,lan_proto,lan_state,mtu_enable,ppp_demand,ppp_idletime,pppoe_lei,pppoe_lef,ppp_passwd,ppp_redialperiod,ppp_service,ppp_username,ppp_custom,pptp_server_ip,pptp_dhcp,wl_security_mode,wan_dns,dnssec_enable,dnscrypt_proxy,dnscrypt_priority,dnscrypt_port,dnscrypt_cmd,wan_gateway,wan_ipaddr,wan_mtu,wan_netmask,wan_proto,wan_wins,wl_wds_enable,wl_channel,wl_closed,wl_crypto,wl_key,wl_key1,wl_key2,wl_key3,wl_key4,wl_lazywds,wl_mode,wl_net_mode,wl_passphrase,wl_radio,wl_radius_ipaddr,wl_radius_port,wl_ssid,wl_wds,wl_wep_bit,wl_wpa_gtk_rekey,wl_wpa_psk,wl_radius_key,wl_auth,wl_hwaddr,wan_islan,t_features,wl_nbw_cap,wl_nctrlsb,wl_nband,wl_phytype,lan_ifname,lan_stp,lan1_ifname,lan1_ipaddr,lan1_netmask,lan1_proto,lan1_stp,dhcp1_start,dhcp1_num,dhcp1_lease,dhcpd1_startip,dhcpd1_endip,lan2_ifname,lan2_ipaddr,lan2_netmask,lan2_proto,lan2_stp,dhcp2_start,dhcp2_num,dhcp2_lease,dhcpd2_startip,dhcpd2_endip,lan3_ifname,lan3_ipaddr,lan3_netmask,lan3_proto,lan3_stp,dhcp3_start,dhcp3_num,dhcp3_lease,dhcpd3_startip,dhcpd3_endip,ppp_mlppp,modem_ipaddr,modem_pin,modem_dev,modem_init,modem_apn,cstats_enable"); %>
 
 /* VLAN-BEGIN */
 var lg = new TomatoGrid();
@@ -733,6 +733,7 @@ function verifyFields(focused, quiet)
 
 /* DNSCRYPT-BEGIN */
 	var p = E('_f_dnscrypt_proxy').checked;
+	E('_dnscrypt_priority').disabled = !p;
 	E('_dnscrypt_port').disabled = !p;
 	E('_dnscrypt_cmd').disabled = !p;
 /* DNSCRYPT-END */
@@ -1794,6 +1795,7 @@ createFieldTable('', [
 /* DNSSEC-END */
 /* DNSCRYPT-BEGIN */
 	{ title: 'DNSCrypt Service', name: 'f_dnscrypt_proxy', type: 'checkbox', value: (nvram.dnscrypt_proxy == 1) },
+	{ title: 'Priority', indent: 2, name: 'dnscrypt_priority', type: 'select', options: [['1','Preferred'],['2','Exclusive'],['0','None']], value: nvram.dnscrypt_priority },
 	{ title: 'Local Port', indent: 2, name: 'dnscrypt_port', type: 'text', maxlen: 5, size: 7, value: nvram.dnscrypt_port },
 	{ title: 'Boot Parameters', indent: 2, name: 'dnscrypt_cmd', type: 'text', maxlen: 256, size: 64, value: nvram.dnscrypt_cmd, suffix: ' <i>(optional)</i>' },
 /* DNSCRYPT-END */


### PR DESCRIPTION
This adds the ability to assign dns priority to dnscrypt.

0=none, none
1=preferred, strict-order
2=exclusive, no-resolv

The names are fairly self explanatory, but maybe a description should be put in also.
